### PR TITLE
Be able to show an avarage memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,15 @@ The memory counter uses `collectgarbage("count")` to get the amount of Lua memor
 3. Using mem.lua - Draw memory usage at specified position or get current memory usage
 
 
-### mem.create(format, position, color)
+### mem.create(format, position, color, show_avarage, avarage_interval)
 Create an instance of the memory counter
 
 **PARAMETERS**
 * `format` (string) - Optional format to draw memory usage in. Defaults to "MEM %dkb"
 * `position` (string) - Optional position to draw memory usage at. Defaults to v3(10, 20, 0)
 * `color` (string) - Optional color to use when drawing memory usage text. Defaults to v4(0,0,1,1)
+- `show_avarage` (bool) - Shows an avarage memory usage during a set amount of frames
+- `avarage_interval` (number) - The amount of frames to calculate the avarage memory usage for
 
 **RETURNS**
 * `instance` (table) - A memory counter counter instance

--- a/metrics/mem.lua
+++ b/metrics/mem.lua
@@ -28,6 +28,8 @@ function M.create(format, position, color, show_avarage, avarage_interval)
 		mem = collectgarbage("count")
 
 		-- Caclulate an avarage memory usage during a 120 frame period
+		if not show_avarage then return end
+		
 		frame = frame + 1
 		if (frame % avarage_interval == 0) then
 			avarage_mem = avarage_mem_sum / avarage_interval

--- a/metrics/mem.lua
+++ b/metrics/mem.lua
@@ -3,20 +3,38 @@ local M = {}
 M.POSITION = vmath.vector3(10, 20, 0)
 M.FORMAT = "MEM %dkb"
 M.COLOR = vmath.vector4(0, 0, 1, 1)
+M.AVARAGE = " - AVG %dkb"
+M.AVARAGE_INTERVAL = 120 -- 2s
 
-function M.create(format, position, color)
+function M.create(format, position, color, show_avarage, avarage_interval)
 	format = format or M.FORMAT
 	position = position or M.POSITION
 	color = color or M.COLOR
+	avarage_interval = avarage_interval or M.AVARAGE_INTERVAL
 
 	local instance = {}
 
 	local mem = collectgarbage("count")
 
+	local frame = 0
+	local avarage_mem = 0
+	local avarage_interval = 120 -- messure an avarage of 2s worth of memory usage
+	local avarage_mem_sum = 0
+	
 	local message = { text = format:format(mem), position = position, color = color }
 	
 	function instance.update()
+	
 		mem = collectgarbage("count")
+
+		-- Caclulate an avarage memory usage during a 120 frame period
+		frame = frame + 1
+		if (frame % avarage_interval == 0) then
+			avarage_mem = avarage_mem_sum / avarage_interval
+			avarage_mem_sum = 0
+		else 
+			avarage_mem_sum = avarage_mem_sum + mem
+		end
 	end
 
 	function instance.mem()
@@ -24,7 +42,11 @@ function M.create(format, position, color)
 	end
 
 	function instance.draw()
-		message.text = format:format(mem)
+		if show_avarage then
+			message.text = format:format(mem) .. M.AVARAGE:format(avarage_mem)
+		else
+			message.text = format:format(mem)
+		end
 		msg.post("@render:", "draw_debug_text", message)
 	end
 	

--- a/metrics/mem.lua
+++ b/metrics/mem.lua
@@ -4,7 +4,7 @@ M.POSITION = vmath.vector3(10, 20, 0)
 M.FORMAT = "MEM %dkb"
 M.COLOR = vmath.vector4(0, 0, 1, 1)
 M.AVARAGE = " - AVG %dkb"
-M.AVARAGE_INTERVAL = 120 -- 2s
+M.AVARAGE_INTERVAL = 120
 
 function M.create(format, position, color, show_avarage, avarage_interval)
 	format = format or M.FORMAT
@@ -18,7 +18,7 @@ function M.create(format, position, color, show_avarage, avarage_interval)
 
 	local frame = 0
 	local avarage_mem = 0
-	local avarage_interval = 120 -- messure an avarage of 2s worth of memory usage
+	local avarage_interval = 120
 	local avarage_mem_sum = 0
 	
 	local message = { text = format:format(mem), position = position, color = color }
@@ -27,7 +27,7 @@ function M.create(format, position, color, show_avarage, avarage_interval)
 	
 		mem = collectgarbage("count")
 
-		-- Caclulate an avarage memory usage during a 120 frame period
+		-- Calculate an avarage memory usage during a 120 frame period
 		if not show_avarage then return end
 		
 		frame = frame + 1

--- a/metrics/mem.script
+++ b/metrics/mem.script
@@ -1,10 +1,15 @@
+-- mem.script
+
+
 go.property("show", true)
 go.property("color", vmath.vector4(0, 0, 1, 1))
+go.property("show_avarage", false)
+go.property("avarage_interval", 120)
 
 local mem = require "metrics.mem"
 
 function init(self)
-	self.instance = mem.create(nil, go.get_world_position(), self.color)
+	self.instance = mem.create(nil, go.get_world_position(), self.color, self.show_avarage, self.avarage_interval)
 end
 
 function update(self, dt)

--- a/metrics/mem.script
+++ b/metrics/mem.script
@@ -1,6 +1,3 @@
--- mem.script
-
-
 go.property("show", true)
 go.property("color", vmath.vector4(0, 0, 1, 1))
 go.property("show_avarage", false)


### PR DESCRIPTION
I had a hard time reading the memory usage when it updated every frame, so I added an optional setting that calculates the average memory usage over a set amount of frames.

Not sure if this is the most efficient way of doing it, but it's at least flexible and it doesn't interfere with how it worked before.
 
Maybe other will benefit from this too, else just reject this PR and I keep it in my own fork :)